### PR TITLE
Fix additional Xcodebuild options not being considered

### DIFF
--- a/xcodebuild/xcodebuild.go
+++ b/xcodebuild/xcodebuild.go
@@ -61,7 +61,7 @@ func (x xcodebuild) TestWithoutBuilding(xctestrun, destination, testRepetitionMo
 		return "", err
 	}
 
-	options := createXcodebuildOptions(xctestrun, destination, testRepetitionMode, maximumTestRepetitions, relaunchTestsForEachRepetition, outputDir, opts)
+	options := createXcodebuildOptions(xctestrun, destination, testRepetitionMode, maximumTestRepetitions, relaunchTestsForEachRepetition, outputDir, opts...)
 	cmd := x.commandFactory.Create("xcodebuild", options, &command.Opts{
 		Stdout: outputWriter,
 		Stderr: outputWriter,

--- a/xcodebuild/xcodebuild.go
+++ b/xcodebuild/xcodebuild.go
@@ -61,7 +61,7 @@ func (x xcodebuild) TestWithoutBuilding(xctestrun, destination, testRepetitionMo
 		return "", err
 	}
 
-	options := createXcodebuildOptions(xctestrun, destination, testRepetitionMode, maximumTestRepetitions, relaunchTestsForEachRepetition, outputDir)
+	options := createXcodebuildOptions(xctestrun, destination, testRepetitionMode, maximumTestRepetitions, relaunchTestsForEachRepetition, outputDir, opts)
 	cmd := x.commandFactory.Create("xcodebuild", options, &command.Opts{
 		Stdout: outputWriter,
 		Stderr: outputWriter,


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context
* There's a bug in the step where additional Xcodebuild options (`xcodebuild_options`) are not being considered.
* This is because a variadic parameter (`opts`) is not being passed to a function call (as this is not a compiler error, because 0 strings are also a valid value for a variadic parameter).

### Changes
* Fixed Xcodebuild options (`opts`) not being passed to the `xcodebuild` command.

### Out of Scope
* Adding unit tests: these will be added in a separate PR.