### PR TITLE
Fix the test selection handling

### DIFF
--- a/xcodebuild/xcodebuild.go
+++ b/xcodebuild/xcodebuild.go
@@ -158,6 +158,8 @@ func createXcodebuildOptions(xctestrun string, onlyTesting, skipTesting []string
 	}
 
 	if 0 < len(onlyTesting) {
+		// This is a string on purpose. It was an array before and the individual parameter escaping (putting it in quotes like "-only-testing:test-identifier")
+		// was not working as xcodebuild did not recognize the arguments. But if all of these parameters are put in a single string and escaped once, it works.
 		var args string
 		for _, identifier := range onlyTesting {
 			args += fmt.Sprintf("-only-testing:%s ", identifier)
@@ -166,6 +168,7 @@ func createXcodebuildOptions(xctestrun string, onlyTesting, skipTesting []string
 	}
 
 	if 0 < len(skipTesting) {
+		// Same as above
 		var args string
 		for _, identifier := range skipTesting {
 			args += fmt.Sprintf("-skip-testing:%s ", identifier)

--- a/xcodebuild/xcodebuild.go
+++ b/xcodebuild/xcodebuild.go
@@ -158,19 +158,19 @@ func createXcodebuildOptions(xctestrun string, onlyTesting, skipTesting []string
 	}
 
 	if 0 < len(onlyTesting) {
-		var args []string
+		var args string
 		for _, identifier := range onlyTesting {
-			args = append(args, fmt.Sprintf("-only-testing:%s", identifier))
+			args += fmt.Sprintf("-only-testing:%s ", identifier)
 		}
-		options = append(options, args...)
+		options = append(options, args)
 	}
 
 	if 0 < len(skipTesting) {
-		var args []string
+		var args string
 		for _, identifier := range skipTesting {
-			args = append(args, fmt.Sprintf("-skip-testing:%s", identifier))
+			args += fmt.Sprintf("-skip-testing:%s ", identifier)
 		}
-		options = append(options, args...)
+		options = append(options, args)
 	}
 
 	return append(options, opts...)

--- a/xcodebuild/xcodebuild_test.go
+++ b/xcodebuild/xcodebuild_test.go
@@ -4,13 +4,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/bitrise-io/go-xcode/v2/destination"
 	"github.com/bitrise-steplib/bitrise-step-xcode-test-without-building/mocks"
-	"github.com/stretchr/testify/mock"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestTestConfiguration(t *testing.T) {
@@ -18,7 +18,7 @@ func TestTestConfiguration(t *testing.T) {
 	commandMock.On("PrintableCommandArgs").Return("")
 	commandMock.On("Run").Return(nil)
 
-	params := []string{"test-without-building", "-xctestrun", "test.xctestrun", "-destination", "id=test-UDID", "-resultBundlePath", "/test/path/Test-test.xcresult", "-only-testing:target1", "-only-testing:target2/testClass1", "-only-testing:target3/testClass1/testFunction", "-skip-testing:target4", "-skip-testing:target5/testClass1", "-skip-testing:target6/testClass1/testFunction"}
+	params := []string{"test-without-building", "-xctestrun", "test.xctestrun", "-destination", "id=test-UDID", "-resultBundlePath", "/test/path/Test-test.xcresult", "-only-testing:target1 -only-testing:target2/testClass1 -only-testing:target3/testClass1/testFunction ", "-skip-testing:target4 -skip-testing:target5/testClass1 -skip-testing:target6/testClass1/testFunction "}
 
 	factoryMock := new(mocks.Factory)
 	factoryMock.On("Create", "xcodebuild", params, mock.Anything).Return(commandMock, nil).Once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

In the previous iteration the test identifiers were added to a list and were fed to the xcodebuild command individually and they were put in quotes. In this case xcodebuild was not understanding them and returned an error that it does not understand the command line flag.

If the whole array was converted to a string and put in quotes then it understood the parameter array. 